### PR TITLE
Add "}" to accumulated code when ending "while" blocks in compile

### DIFF
--- a/drol.py
+++ b/drol.py
@@ -265,7 +265,7 @@ def compile(drol_string, outfile, header = 1): # Compile DROL code into C code
                     outfile.write('}\n')
                 else:
                     code = code + compile(mini_block, outfile, 0)
-                    outfile.write('}\n')
+                    code = code + '}\n'
                 location = location + block_length + header_length + 1
                 i = 0
                 while i != block_length + header_length:


### PR DESCRIPTION
Minor change... Looks like the code was updated at some point and the "while" logic missed getting a change.  The logic that adds "}" to the generated C source code ends up getting written ahead of the logic in the block when there are nested "while" loops.